### PR TITLE
fix: 修复下载路径在Unix-like操作系统下出错的问题

### DIFF
--- a/src/electron/download.js
+++ b/src/electron/download.js
@@ -1,4 +1,5 @@
-const { ipcMain } =  require('electron')
+const { ipcMain } =  require('electron');
+const path = require('path');
 const Store = require('electron-store');
 module.exports = MusicDownload = (win) => {
     const settingsStore = new Store({name: 'settings'})
@@ -14,12 +15,12 @@ module.exports = MusicDownload = (win) => {
         downloadObj.downloadUrl = args.url
         downloadObj.type = args.type
         const savePath = await settingsStore.get('settings')
-        downloadObj.savePath = savePath.local.downloadFolder + '\\'
+        downloadObj.savePath = savePath.local.downloadFolder
         win.webContents.downloadURL(downloadObj.downloadUrl)
     })
 
     win.webContents.session.on('will-download', (event, item, webContents) => {
-        item.setSavePath(downloadObj.savePath + downloadObj.fileName + '.' + downloadObj.type)
+        item.setSavePath(path.join(downloadObj.savePath, downloadObj.fileName + '.' + downloadObj.type))
 
         const totalBytes = item.getTotalBytes();
 


### PR DESCRIPTION
选择 /home/user/Music 作为保存目录，会将文件写入到 /home/user/Music\音乐文件名 下
如图所示：
![Image](https://user-images.githubusercontent.com/49718840/222180059-3a294608-fe5d-400d-a0ea-9b7b408f79f1.png)
