### PR TITLE
feat: 增加字体简单自定义功能

### DIFF
--- a/src/electron/ipcMain.js
+++ b/src/electron/ipcMain.js
@@ -330,4 +330,15 @@ module.exports = IpcMainEvent = (win, app) => {
     ipcMain.on('set-window-title', (e, title) => {
         win.setTitle(title)
     })
+    ipcMain.handle('select-file', async (e) => {
+        const filters = [
+            {name: 'Fonts', extensions:['woff','woff2','ttf','otf','eot']}
+        ]
+        const { canceled, filePaths } = await dialog.showOpenDialog({properties: ['openFile'],filters})
+        if (canceled) {
+            return null
+        } else {
+            return filePaths[0]
+        }
+    })
 }

--- a/src/electron/preload.js
+++ b/src/electron/preload.js
@@ -158,6 +158,7 @@ contextBridge.exposeInMainWorld('windowApi', {
     deleteMusicVideo: (id) => ipcRenderer.invoke('delete-music-video', id),
     getLocalMusicLyric: (filePath) => ipcRenderer.invoke('get-local-music-lyric', filePath),
     copyTxt,
+    selectFile: () => ipcRenderer.invoke('select-file'),
     checkUpdate,
     setWindowTile,
 })

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -60,7 +60,8 @@
   const shortcutsList = ref(null)
   const selectedShortcut = ref(null)
   const newShortcut = ref([])
-  const shortcutCharacter  = ['=', '-', '~', '@', '#', '$', '[', ']', ';', "'", ',', '.', '/', '!'];
+const shortcutCharacter = ['=', '-', '~', '@', '#', '$', '[', ']', ';', "'", ',', '.', '/', '!'];
+  const customFont = ref('')
 
   if(isLogin()) {
     getVipInfo().then(result => {
@@ -80,8 +81,10 @@
         localFolder.value = settings.local.localFolder
         shortcutsList.value = settings.shortcuts
         globalShortcuts.value = settings.other.globalShortcuts
-        quitApp.value = settings.other.quitApp
+		quitApp.value = settings.other.quitApp
+		customFont.value = settings.other.customFont
     })
+	insertCustomFontStyle()
   })
 
   const setAppSettings = () => {
@@ -101,7 +104,8 @@
         shortcuts: shortcutsList.value,
         other: {
             globalShortcuts: globalShortcuts.value,
-            quitApp: quitApp.value
+			quitApp: quitApp.value,
+			customFont: customFont.value
         }
     }
     windowApi.setSettings(JSON.stringify(settings))
@@ -251,6 +255,36 @@
   }
   const toGithub = () => {
     windowApi.toRegister("https://github.com/Kaidesuyo/Hydrogen-Music")
+}
+const insertCustomFontStyle = (init = false) => {
+	const head = document.querySelector('head')
+	if (init) {
+		customFont.value = ''
+		head.querySelector('#__CUSTOM_FONT__').remove()
+	}
+	else if (customFont.value.length) {
+	const str = `
+		@font-face {
+			font-family: SourceHanSansCN-Bold,
+			src: url(${customFont.value});
+		}`, el = head.querySelector('#__CUSTOM_FONT__')
+		if (el) {
+			el.innerHTML = str
+		}
+		else {
+			const style = document.createElement('style')
+			style.setAttribute('id', '__CUSTOM_FONT__')
+			style.innerHTML = 
+			head.appendChild(style)
+		}
+		alert(head.querySelector('#__CUSTOM_FONT__'))
+	}
+}
+const setCustomFont = () => {
+	windowApi.selectFile().then(path => {
+		customFont.value = path.replaceAll('\\','/')
+		insertCustomFontStyle()
+	})
   }
 </script>
 
@@ -428,6 +462,14 @@
                                     <div class="toggle-on" v-show="userStore.cloudDiskPage"></div>
                                 </Transition>
                             </div>
+                        </div>
+                    </div>
+                    <div class="option">
+                        <div class="option-name">自定义字体</div>
+                        <div class="custom-font local-folder">
+                            <div class="custom-font-path">{{customFont ? customFont : '未设置'}}</div>
+                            <div class="add-option" @click="insertCustomFontStyle(true)">重置</div>
+                            <div class="add-option" @click="setCustomFont()">选择</div>
                         </div>
                     </div>
                     <div class="option">
@@ -732,6 +774,17 @@
                                 }
                             }
                         }
+						.custom-font {
+							.custom-font-path {
+								width: 50vw;
+								height: 30px;
+								background-color: rgba(255, 255, 255, 0.35);
+								font: 13px SourceHanSansCN-Bold;
+								color: black;
+								line-height: 30px;
+								overflow: hidden;
+							}
+						}
                     }
                     .forbid-shortcuts{
                         opacity: 0.5;

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -61,7 +61,7 @@
   const selectedShortcut = ref(null)
   const newShortcut = ref([])
 const shortcutCharacter = ['=', '-', '~', '@', '#', '$', '[', ']', ';', "'", ',', '.', '/', '!'];
-  const customFont = ref('')
+const customFont = ref('')
 
   if(isLogin()) {
     getVipInfo().then(result => {
@@ -82,7 +82,7 @@ const shortcutCharacter = ['=', '-', '~', '@', '#', '$', '[', ']', ';', "'", ','
         shortcutsList.value = settings.shortcuts
         globalShortcuts.value = settings.other.globalShortcuts
 		quitApp.value = settings.other.quitApp
-		customFont.value = settings.other.customFont
+        customFont.value = settings.other.customFont
     })
 	insertCustomFontStyle()
   })
@@ -105,7 +105,7 @@ const shortcutCharacter = ['=', '-', '~', '@', '#', '$', '[', ']', ';', "'", ','
         other: {
             globalShortcuts: globalShortcuts.value,
 			quitApp: quitApp.value,
-			customFont: customFont.value
+            customFont: customFont.value,
         }
     }
     windowApi.setSettings(JSON.stringify(settings))
@@ -255,36 +255,33 @@ const shortcutCharacter = ['=', '-', '~', '@', '#', '$', '[', ']', ';', "'", ','
   }
   const toGithub = () => {
     windowApi.toRegister("https://github.com/Kaidesuyo/Hydrogen-Music")
-}
-const insertCustomFontStyle = (init = false) => {
-	const head = document.querySelector('head')
-	if (init) {
-		customFont.value = ''
-		head.querySelector('#__CUSTOM_FONT__').remove()
-	}
-	else if (customFont.value.length) {
-	const str = `
-		@font-face {
-			font-family: SourceHanSansCN-Bold,
-			src: url(${customFont.value});
-		}`, el = head.querySelector('#__CUSTOM_FONT__')
-		if (el) {
-			el.innerHTML = str
-		}
-		else {
-			const style = document.createElement('style')
-			style.setAttribute('id', '__CUSTOM_FONT__')
-			style.innerHTML = 
-			head.appendChild(style)
-		}
-		alert(head.querySelector('#__CUSTOM_FONT__'))
-	}
-}
-const setCustomFont = () => {
-	windowApi.selectFile().then(path => {
-		customFont.value = path.replaceAll('\\','/')
-		insertCustomFontStyle()
-	})
+  }
+  const insertCustomFontStyle = (init = false) => {
+  	const head = document.querySelector('head')
+  	if (init) {
+  		customFont.value = ''
+  		head.querySelector('#__CUSTOM_FONT__').remove()
+  	}
+  	else if (customFont.value.length) {
+  	const str = `
+  		@font-face {
+  			font-family: SourceHanSansCN-Bold;
+              font-weight: 'bold';
+  			src: local(${customFont.value});
+  		}`, el = head.querySelector('#__CUSTOM_FONT__')
+  		if (el) {
+  			el.innerHTML = str
+  		}
+  		else {
+  			const style = document.createElement('style')
+  			style.setAttribute('id', '__CUSTOM_FONT__')
+  			style.innerHTML = 
+  			head.appendChild(style)
+  		}
+  	}
+  }
+  const setCustomFont = () => {
+        insertCustomFontStyle(customFont.value.length ? false : true)
   }
 </script>
 
@@ -467,9 +464,8 @@ const setCustomFont = () => {
                     <div class="option">
                         <div class="option-name">自定义字体</div>
                         <div class="custom-font local-folder">
-                            <div class="custom-font-path">{{customFont ? customFont : '未设置'}}</div>
-                            <div class="add-option" @click="insertCustomFontStyle(true)">重置</div>
-                            <div class="add-option" @click="setCustomFont()">选择</div>
+                            <!-- <div class="custom-font-path">{{customFont ? customFont : '未设置'}}</div> -->
+                            <input type="text" placeholder="输入本地已安装字体名字" @blur="setCustomFont()" v-model.lazy="customFont">
                         </div>
                     </div>
                     <div class="option">
@@ -767,6 +763,11 @@ const setCustomFont = () => {
                                 color: black;
                                 background-color: rgba(255, 255, 255, 0.35);
                                 transition: 0.2s;
+                                &.selected {
+                                    color: white;
+                                    background-color: black;
+                                    box-shadow: 0 0 0 1px black;
+                                }
                                 &:hover{
                                     cursor: pointer;
                                     opacity: 0.8;


### PR DESCRIPTION
目前实现思路：用户在本地安装字体，然后在软件内手动设置字体名字

粗体细体均由用户决定

内部使用 `@font-family` 的 local 属性来获取用户本地字体

目前已经完成了一个最简单的替换，下面是截图预览：

正常状态：
![正常状态](https://user-images.githubusercontent.com/86217807/222622513-ce584cc2-db29-49ca-8ac8-28d39233363c.png)

选用内置微软雅黑：
![微软雅黑](https://user-images.githubusercontent.com/86217807/222622664-9ae3dbd0-3a0e-4bb9-a650-1a870289f153.png)

选用微软雅黑粗体：
![微软雅黑粗体](https://user-images.githubusercontent.com/86217807/222622729-f6a86876-262c-410c-a513-6ab4a90ab703.png)

输入框内直接输入字体名字后即可设置，输入框监听的是失去焦点事件，失去焦点后触发修改事件

PS：看源代码总觉得这个文件没格式化，但是自己格式化后又几乎每一行都会变化，挺难受的

解决 issue：https://github.com/Kaidesuyo/Hydrogen-Music/issues/48